### PR TITLE
update error prompts

### DIFF
--- a/tenkit/mro/stages/make_fastqs/make_qc_summary/__init__.py
+++ b/tenkit/mro/stages/make_fastqs/make_qc_summary/__init__.py
@@ -235,6 +235,9 @@ This error is usually caused by one of the following:
 3. Your sequencing data might be of such low quality that all the reads
    ended up in the "Undetermined" FASTQs. Please double check the quality
    of your sequence data.
+4. You have provided an incorrect ID parameter to spaceranger. Specifically,
+   you have used "spaceranger mkfastq -id" instead of "spaceranger mkfastq
+   --id".
 """)
 
     chunk_defs = [{'input_files': file_list, 'project': tup[0], 'lane': tup[1], 'sample': tup[2], 'subfolder': tup[3]} for tup, file_list in sorted(chunk_dict.items())]


### PR DESCRIPTION
Dear Sina,

I hope this email finds you well. I am writing to share a suggestion about Spaceranger. I highly recommend that Spaceranger add an error prompt that can prevent other users from being misled. As a recent user, I encountered several misleading error prompts that caused me some issues, prompting me to share my experience with Matthew via email, which I have attached at the end of this email.

I believe adding an error prompt can prevent other users from experiencing the same problem, making the user experience smoother and more enjoyable. I appreciate the time and effort Spaceranger puts into ensuring a seamless user experience, and I am confident that this small addition can tremendously enhance the platform's performance.

Thank you for taking the time to read my email, and I look forward to hearing from you.

Best regards,

    Hello Matthew,

    I hope this message finds you well. I was hoping to offer a quick suggestion to the developer of Spaceranger. Would it be possible to include an additional error explanation to the following list? For instance, "id is not parsed." Alternatively, it may be best to remove the list altogether as it could be very misleading.

    >  [error]
    >       No FASTQs matched your sample sheet's lane, sample, and indexes.
    >       This error is usually caused by one of the following:
    >       1. You are demultiplexing a NovaSeq flowcell, but you are using an older
    >   version of bcl2fastq. Please upgrade to bcl2fastq 2.20+.
    >       2. There may be a mistake in your samplesheet, please double check that
    >   you are specifying the right lanes, samples, and index sets.
    >       3. Your sequencing data might be of such low quality that all the reads
    >   ended up in the "Undetermined" FASTQs. Please double check the quality
    >   of your sequence data.

    Thank you for taking the time to read my email. I appreciate your attention to this matter.


    Best,